### PR TITLE
Fix panic in the Search function

### DIFF
--- a/flash/flashtext.go
+++ b/flash/flashtext.go
@@ -229,10 +229,10 @@ type Result struct {
 // Search in the text for the stored keys in the trie and
 // returns a slice of `Result`
 func (tree *FlashKeywords) Search(text string) []Result {
-	n := len(text)
 	if !tree.caseSensitive {
 		text = strings.ToLower(text)
 	}
+	n := len(text)
 	var res []Result
 	currentNode := tree.root
 	start := 0

--- a/flash/flashtext.go
+++ b/flash/flashtext.go
@@ -114,11 +114,12 @@ func (tree *FlashKeywords) AddKeyWord(word string, cleanWord string) {
 }
 
 // Add Multiple Keywords simultaneously from a map example:
-//	keyword_dict = {
-//  	"java": ["java_2e", "java programing"],
-//  	"product management": ["PM", "product manager"]
-// 	}
-// 	trie.AddFromMap(keyword_dict)
+//
+//		keyword_dict = {
+//	 	"java": ["java_2e", "java programing"],
+//	 	"product management": ["PM", "product manager"]
+//		}
+//		trie.AddFromMap(keyword_dict)
 func (tree *FlashKeywords) AddFromMap(keys2synonyms map[string][]string) {
 
 	for key, listSynonyms := range keys2synonyms {
@@ -212,12 +213,12 @@ func (tree *FlashKeywords) RemoveKey(word string) bool {
 }
 
 // the resulting output struct:
-//	- `Key`: the string keyword found in the search text
-//	- `IsPrefix` (false/true): indicates if the key A is a prefix of another string(key B)
-//		where A and B are both in the dictionary of the flash keywords
-//	- `CleanWord`: the string with which the found key will be replaced in the text.
-//               We can think of it also like the origin word of the synonym found in the text.
-//	- `Start & End`: span information about the start and end indexes if the key found in the text
+//   - `Key`: the string keyword found in the search text
+//   - `IsPrefix` (false/true): indicates if the key A is a prefix of another string(key B)
+//     where A and B are both in the dictionary of the flash keywords
+//   - `CleanWord`: the string with which the found key will be replaced in the text.
+//     We can think of it also like the origin word of the synonym found in the text.
+//   - `Start & End`: span information about the start and end indexes if the key found in the text
 type Result struct {
 	Key       string
 	IsPrefix  bool // support for key the smallest(the prefix) and the longest match

--- a/flash/flashtext_test.go
+++ b/flash/flashtext_test.go
@@ -132,6 +132,21 @@ func TestCaseSensitive(t *testing.T) {
 	t.Logf("allkeys: %v", allKeys)
 }
 
+func TestFalseCaseInsensitiveSearchUnicodeDoesNotPanic(t *testing.T) {
+	trie := NewFlashKeywords(false)
+	keys := []string{"İUseUnicode", "İUseUnicodeToBreakThings"}
+	for _, k := range keys {
+		trie.Add(k)
+	}
+	text := "İUseUnicode"
+	res := trie.Search(text)
+	assert.Equal(t, len(res), 1)
+	for i := 0; i < len(res); i++ {
+		assert.Equal(t, res[i].Key, strings.ToLower(keys[i]))
+	}
+	t.Logf("Search Result: %v", res)
+}
+
 func TestFalseCaseSensitiveSearch(t *testing.T) {
 	trie := NewFlashKeywords(false)
 	keys := []string{"FoO", "Banana"}
@@ -233,7 +248,6 @@ func TestOverlapRemoveKeys_2(t *testing.T) {
 	assert.Equal(t, len(trie.GetAllKeywords()), 1)
 	assert.Equal(t, trie.nbrNodes, len(keys[0])+1)
 	t.Logf("Size: %v, allKeys: %v, nbrNode: %v", trie.Size(), trie.GetAllKeywords(), trie.nbrNodes)
-
 }
 
 func TestOverlapRemoveKeys_3(t *testing.T) {
@@ -263,7 +277,6 @@ func TestOverlapRemoveKeys_3(t *testing.T) {
 	}
 	assert.Equal(t, trie.nbrNodes, nodes)
 	t.Logf("%v nbrNode: %v %v", trie.GetAllKeywords(), trie.nbrNodes, nodes)
-
 }
 
 func TestGoBackToRootTrick(t *testing.T) {
@@ -320,7 +333,9 @@ func TestAddFromMap(t *testing.T) {
 
 func TestAddFromFile(t *testing.T) {
 	trie := NewFlashKeywords(true)
-	trie.AddFromFile("./../testdata/Keys2Synonyms.txt")
+	err := trie.AddFromFile("./../testdata/Keys2Synonyms.txt")
+	assert.Nil(t, err)
+
 	testdata := []struct {
 		key        string
 		originWord string
@@ -421,6 +436,7 @@ func TestReplaceCleanWordSameLenghtKey(t *testing.T) {
 	assert.Equal(t, newText, rText)
 	t.Logf("newText: %v", newText)
 }
+
 func TestReplaceKeyAtTheEnd(t *testing.T) {
 	trie := NewFlashKeywords(true)
 	trie.AddKeyWord("in place", "gone")


### PR DESCRIPTION
This pull request fixes an issue with Search where certain unicode strings could cause Search to panic:

Explanation:
```go
func (tree *FlashKeywords) Search(text string) []Result {
   n := len(text)
    if !tree.caseSensitive {
        // The strings.ToLower call can make the resulting string have a *shorter*
        // length, for certain unicode characters
        text = strings.ToLower(text)
    }

    ...

    // Because the length of the text after lowercasing can be smaller,
    // text[idx+1] can panic with certain unicode strings
    if idx+1 < n {
        if _, ok := currentNode.children[rune(text[idx+1])]; ok {
```

Demo:
```go
package main

import (
	"fmt"

	"github.com/ayoyu/flashtext/flash"
)

func main() {
	fk := flash.NewFlashKeywords(false)

	fk.Add("İbrahim")
	fk.Add("İbra")

	// res := fk.Search("İbra")
	res := fk.Search("İbra")
	for _, item := range res {
		fmt.Println(item)
	}
}
```

```bash
go run ./main.go
panic: runtime error: index out of range [4] with length 4

goroutine 1 [running]:
github.com/ayoyu/flashtext/flash.(*FlashKeywords).Search(0xc000104ed8, {0x4a4b24?, 0x5})
	/home/user/src/github.com/ayoyu/flashtext/flash/flashtext.go:250 +0x3f4
main.main()
	/home/user/src/github.com/ayoyu/flashtext/main.go:16 +0xdc
exit status 2
```

This PR moves the length setting to *after* the `strings.ToLower` call.



